### PR TITLE
Reformat membership tier layout

### DIFF
--- a/resources/markdown/companies.md
+++ b/resources/markdown/companies.md
@@ -1,4 +1,4 @@
-Title: Company Membership  
+Title: Company Membership
 
 
 Companies using Clojure depend on many open-source libraries and tools. Clojurists Together memberships offer a way for companies to support the Clojure community, and ensure that the software they build their businesses on is maintained and improved.
@@ -16,15 +16,13 @@ Companies using Clojure depend on many open-source libraries and tools. Clojuris
 Clojurists Together is a member project of the [Software Freedom Conservancy](https://sfconservancy.org) which is a 501\(c)3 organisation. This means that your support is likely tax deductible in the USA. If you have any questions, please [get in touch](/contact) or talk to your accountant.
 
 <section class="membership-tiers">
-<p>All memberships can be paid monthly or annually.</p> 
+<p>All memberships can be paid monthly or annually.</p>
+
+
 <section class="membership-tier">
 <h3>Assoc Member</h3>
-
 <b>$50 per month</b>
-
 <p>Vote on board members, get progress updates, influence which projects are selected, recognition on the Clojurists Together website.</p>
-
-
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
 %<input type="hidden" name="hosted_button_id" value="7MEVKKH4TQ336">%
@@ -33,73 +31,63 @@ Clojurists Together is a member project of the [Software Freedom Conservancy](ht
 <td>
 <input type="hidden" name="on0" value="Membership Level"></td></tr>
 <tr><td><select name="os0">
-	<option value="Monthly Assoc Membership">Monthly Assoc Membership : $50.00 USD - monthly</option>
-	<option value="Yearly Assoc Membership">Yearly Assoc Membership : $600.00 USD - yearly</option>
+<option value="Monthly Assoc Membership">Monthly Assoc Membership : $50 USD - monthly</option>
+<option value="Yearly Assoc Membership">Yearly Assoc Membership : $600 USD - yearly</option>
 </select> </td></tr>
 </table>
 <input type="hidden" name="currency_code" value="USD">
 <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 <button class="become-a-member">Become an Assoc Member!</button>
 </form>
-
-
 </section>
+
 
 <section class="membership-tier">
 <h3>Cons Member</h3>
-
 <b>$100 per month</b>
 
 <p>Vote on board members, get progress updates, influence which projects are selected, recognition on the Clojurists Together website.</p>
-
 
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
 %<input type="hidden" name="hosted_button_id" value="7BLAYU6JEPXZ6">%
 <table>
 <tr><td><input type="hidden" name="on0" value="Membership Level"></td></tr><tr><td><select name="os0">
-	<option value="Monthly Cons Membership">Monthly Cons Membership : $100.00 USD - monthly</option>
-	<option value="Yearly Cons Membership">Yearly Cons Membership : $1,200.00 USD - yearly</option>
+<option value="Monthly Cons Membership">Monthly Cons Membership : $100 USD - monthly</option>
+<option value="Yearly Cons Membership">Yearly Cons Membership : $1,200 USD - yearly</option>
 </select> </td></tr>
 </table>
 <input type="hidden" name="currency_code" value="USD">
-
 <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 <button class="become-a-member">Become a Cons Member!</button>
 </form>
-
-
 </section>
+
 
 <section class="membership-tier">
 <h3>Into Member</h3>
-
 <b>$200 per month</b>
 
 <p>Vote on board members, get progress updates, influence which projects are selected, recognition on the Clojurists Together website.</p>
-
 
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
 %<input type="hidden" name="hosted_button_id" value="3486MRLANRSDQ">%
 <table>
 <tr><td><input type="hidden" name="on0" value="Membership Level"></td></tr><tr><td><select name="os0">
-	<option value="Monthly Into Membership">Monthly Into Membership : $200.00 USD - monthly</option>
-	<option value="Yearly Into Membership">Yearly Into Membership : $2,400.00 USD - yearly</option>
+<option value="Monthly Into Membership">Monthly Into Membership : $200 USD - monthly</option>
+<option value="Yearly Into Membership">Yearly Into Membership : $2,400 USD - yearly</option>
 </select> </td></tr>
 </table>
 <input type="hidden" name="currency_code" value="USD">
-
 <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 <button class="become-a-member">Become an Into Member!</button>
 </form>
-
-
 </section>
+
 
 <section class="membership-tier">
 <h3>Filter Member</h3>
-
 <b>$500 per month</b>
 
 <p>Influence which projects are selected</p>
@@ -112,28 +100,24 @@ Clojurists Together is a member project of the [Software Freedom Conservancy](ht
 
 <p>Thank you tweet from <a href="https://twitter.com/cljtogether">@cljtogether</a></p></p>
 
-
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
 %<input type="hidden" name="hosted_button_id" value="ZCVLMJNPFJJMJ">%
 <table>
 <tr><td><input type="hidden" name="on0" value="Membership Level"></td></tr><tr><td><select name="os0">
-	<option value="Monthly Filter Membership">Monthly Filter Membership : $500.00 USD - monthly</option>
-	<option value="Yearly Filter Membership">Yearly Filter Membership : $6,000.00 USD - yearly</option>
+<option value="Monthly Filter Membership">Monthly Filter Membership : $500 USD - monthly</option>
+<option value="Yearly Filter Membership">Yearly Filter Membership : $6,000 USD - yearly</option>
 </select> </td></tr>
 </table>
 <input type="hidden" name="currency_code" value="USD">
-
 <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 <button class="become-a-member">Become a Filter Member!</button>
 </form>
-
-
 </section>
+
 
 <section class="membership-tier">
 <h3>Transduce Member</h3>
-
 <b>$1000 per month</b>
 
 <p>Influence on which projects are selected</p>
@@ -148,28 +132,24 @@ Clojurists Together is a member project of the [Software Freedom Conservancy](ht
 
 <p>Thank you tweet from <a href="https://twitter.com/cljtogether">@cljtogether</a></p>
 
-
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
 %<input type="hidden" name="hosted_button_id" value="3HUZJEBTYBLJA">%
 <table>
 <tr><td><input type="hidden" name="on0" value="Membership Level"></td></tr><tr><td><select name="os0">
-	<option value="Monthly Transduce Membership">Monthly Transduce Membership : $1,000.00 USD - monthly</option>
-	<option value="Yearly Transduce Membership">Yearly Transduce Membership : $12,000.00 USD - yearly</option>
+<option value="Monthly Transduce Membership">Monthly Transduce Membership : $1,000 USD - monthly</option>
+<option value="Yearly Transduce Membership">Yearly Transduce Membership : $12,000 USD - yearly</option>
 </select> </td></tr>
 </table>
 <input type="hidden" name="currency_code" value="USD">
-
 <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 <button class="become-a-member">Become a Transduce Member!</button>
 </form>
-
-
 </section>
+
 
 <section class="membership-tier">
 <h3>Map Member</h3>
-
 <b>$2000 per month</b>
 
 <p>Influence on which projects are selected</p>
@@ -186,28 +166,24 @@ Clojurists Together is a member project of the [Software Freedom Conservancy](ht
 
 <p>Customized thank you tweet each month by <a href="https://twitter.com/cljtogether">@cljtogether</a></p>
 
-
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
 %<input type="hidden" name="hosted_button_id" value="YT98PJMCVF5U8">%
 <table>
 <tr><td><input type="hidden" name="on0" value="Membership Level"></td></tr><tr><td><select name="os0">
-	<option value="Monthly Map Membership">Monthly Map Membership : $2,000.00 USD - monthly</option>
-	<option value="Yearly Map Membership">Yearly Map Membership : $24,000.00 USD - yearly</option>
+<option value="Monthly Map Membership">Monthly Map Membership : $2,000 USD - monthly</option>
+<option value="Yearly Map Membership">Yearly Map Membership : $24,000 USD - yearly</option>
 </select> </td></tr>
 </table>
 <input type="hidden" name="currency_code" value="USD">
-
 <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 <button class="become-a-member">Become a Map Member!</button>
 </form>
-
-
 </section>
+
 
 <section class="membership-tier">
 <h3>Reduce Member</h3>
-
 <b>$5000 per month</b>
 
 <p>Influence on which projects are selected</p>
@@ -228,21 +204,17 @@ Clojurists Together is a member project of the [Software Freedom Conservancy](ht
 
 <p>Twice-monthly status reports with more detail</p>
 
-
 <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
 <input type="hidden" name="cmd" value="_s-xclick">
 %<input type="hidden" name="hosted_button_id" value="SSJ294XGD9DZJ">%
 <table>
 <tr><td><input type="hidden" name="on0" value="Membership Level"></td></tr><tr><td><select name="os0">
-	<option value="Monthly Reduce Membership">Monthly Reduce Membership : $5,000.00 USD - monthly</option>
-	<option value="Yearly Reduce Membership">Yearly Reduce Membership : $60,000.00 USD - yearly</option>
+<option value="Monthly Reduce Membership">Monthly Reduce Membership : $5,000 USD - monthly</option>
+<option value="Yearly Reduce Membership">Yearly Reduce Membership : $60,000 USD - yearly</option>
 </select> </td></tr>
 </table>
 <input type="hidden" name="currency_code" value="USD">
-
 <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 <button class="become-a-member">Become a Reduce Member!</button>
 </form>
-
-
 </section>

--- a/resources/public/app.css
+++ b/resources/public/app.css
@@ -67,20 +67,46 @@ footer hr {
 
 .membership-tier {
     min-width: 300px;
-    width: 45%;
-    padding: 5px;
+    width: 100%;
+    padding: 20px 20px 25px;
+    background: whitesmoke;
+    border-radius: 7px;
+}
+
+.membership-tier h3 {
+    font-size: 36px;
+    margin: 0 0 15px;
+}
+
+.membership-tier p {
+    font-size: 16px;
+    max-width: 500px;
+}
+
+.membership-tier table {
+    border-spacing: 0px;
+}
+
+.membership-tier img {
+    display: block;
 }
 
 .become-a-member {
+    background-image: linear-gradient(to bottom, #5d325d, #380036);
     background-color: #380036;
     color: white;
     font-size: 16px;
+    font-weight: 700;
     display: inline-block;
-    padding: 10px 15px 9px 15px;
-    margin: 2px 0px;
+    padding: 12px 30px;
+    margin: 29px 0 0;
     border-radius: 6px;
+    cursor: pointer;
 }
 
+.become-a-member:hover{
+    background-image: linear-gradient(to bottom, #733e72, #481448);
+}
 header a {
     text-decoration: none;
 }


### PR DESCRIPTION
- Reformat membership tiers on `companies` and `developers` pages into single-column layouts.

- Place each tier in a panel with subtle light gray bg, 20px of padding, and 8px rounded corners. 

- Increase tier label type size for visual parity with page `h1`.

- Decrease tier description paragraph type size to 16px and limit paragraph width to 500px.

- Normalize markdown to remove non-explicit paragraph elements.

- Adjust margins of tier panel children to create regular, rhythmic vertical spacing between them.

- Give paypal pixel `display:block` to keep it from pushing signup button to the right

- Remove `border-spacing` from `table` elements within tier panel in order to left justify all panel children

- Slightly increase horizontal padding of sign up button

- Add `cursor: pointer` to button for expected behavior

- Add very slight gradient to button as well as subtle tonal shift on hover

- Remove `.00` from USD amounts