### PR TITLE
Remove duplicate reference to ClojureDart

### DIFF
--- a/data/projects.yaml
+++ b/data/projects.yaml
@@ -135,13 +135,6 @@
   date: 2022-09-01
   round: Q3 2022
   current: false
-- name: ClojureDart
-  url: https://github.com/Tensegritics/ClojureDart
-  tier: USD 9k
-  description: A port of Clojure that compiles to Dart
-  date: 2022-09-01
-  round: Q3 2022
-  current: false
 - name: Clojure Data Cookbook
   url: https://github.com/scicloj/clojure-data-cookbook
   tier: USD 9k


### PR DESCRIPTION
I was looking through the projects page and noticed that ClojureDart appears to be duplicated. Tested by running `hugo server` and seeing that the duplicate entry is removed.

See: https://www.clojuriststogether.org/projects/